### PR TITLE
Fix Issue #1: Inconsistent Sidebar Styles

### DIFF
--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -1,5 +1,5 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
   <div class="sidebar_body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>

--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
   <h3 class="sidebar-title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
This fix resolves Issue #1, where styles were not behaving correctly because of incorrectly referenced classes `sidebar-title` and `sidebar-body` used `_` instead of `-`.
