### PR TITLE
Fixed issue #7 - Sign-in form displays raw span html in input fields

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,11 +5,11 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <fieldset>
     <div class="form-group">
-      <%= f.text_field :login, class: 'form-control', placeholder: t('.login'), autofocus: true %>
+      <%= f.text_field :login, class: 'form-control', placeholder: 'Login', autofocus: true %>
     </div>
 
     <div class="form-group">
-      <%= f.password_field :password, class: 'form-control', placeholder: t('.password'), autocomplete: 'off' %>
+      <%= f.password_field :password, class: 'form-control', placeholder: 'Password', autocomplete: 'off' %>
     </div>
 
     <div class="checkbox">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,11 +5,13 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <fieldset>
     <div class="form-group">
-      <%= f.text_field :login, class: 'form-control', placeholder: t('.login'), autofocus: true %>
+      <label for="login"><%= t('.login')%></label>
+      <%= f.text_field :login, class: 'form-control', autofocus: true %>
     </div>
 
     <div class="form-group">
-      <%= f.password_field :password, class: 'form-control', placeholder: t('.password'), autocomplete: 'off' %>
+      <label for="password"><%= t('.password')%></label>
+      <%= f.password_field :password, class: 'form-control', autocomplete: 'off' %>
     </div>
 
     <div class="checkbox">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,13 +5,11 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <fieldset>
     <div class="form-group">
-      <label for="login"><%= t('.login')%></label>
-      <%= f.text_field :login, class: 'form-control', autofocus: true %>
+      <%= f.text_field :login, class: 'form-control', placeholder: t('.login'), autofocus: true %>
     </div>
 
     <div class="form-group">
-      <label for="password"><%= t('.password')%></label>
-      <%= f.password_field :password, class: 'form-control', autocomplete: 'off' %>
+      <%= f.password_field :password, class: 'form-control', placeholder: t('.password'), autocomplete: 'off' %>		
     </div>
 
     <div class="checkbox">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,11 +5,11 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <fieldset>
     <div class="form-group">
-      <%= f.text_field :login, class: 'form-control', placeholder: 'Login', autofocus: true %>
+      <%= f.text_field :login, class: 'form-control', placeholder: t('.login'), autofocus: true %>
     </div>
 
     <div class="form-group">
-      <%= f.password_field :password, class: 'form-control', placeholder: 'Password', autocomplete: 'off' %>
+      <%= f.password_field :password, class: 'form-control', placeholder: t('.password'), autocomplete: 'off' %>
     </div>
 
     <div class="checkbox">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -733,7 +733,7 @@ en:
       this_comment_has_been_flagged_for_moderator_approval: This comment has been flagged for moderator approval.  It won't appear on this blog until the author approves it
   date:
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -747,7 +747,7 @@ en:
     - Nov
     - Dec
     month_names:
-    - 
+    -
     - January
     - February
     - March
@@ -760,6 +760,11 @@ en:
     - October
     - November
     - December
+  devise:
+    sessions:
+      new:
+        login: Login
+        password: Password
   errors:
     article_type_already_exist: This article type already exists
     cant_end_with_rss_or_atom: Can't end in .rss or .atom. These are reserved for feed URLs


### PR DESCRIPTION
Fixes #7 
In app/views/devise/sessions/new.html.erb: 
- Replaced the placeholder for :login with the string 'Login'. Was t('.login') previously
- Replaced the placeholder for :password with the string 'Password'. Was t('.password') previously
