### PR TITLE
#3 Months sorted incorrectly (Archive Sidebar)

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -7,7 +7,8 @@
   <fieldset>
 
     <div class='form-group'>
-    <%= f.email_field :email, class: 'form-control', placeholder: t('.email') %>
+    <%= f.label :email, t('.email') %>
+    <%= f.email_field :email, class: 'form-control', placeholder: 'Email' %>
     </div>
 
     <div class='form-group'>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,11 +5,13 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <fieldset>
     <div class="form-group">
-      <%= f.text_field :login, class: 'form-control', placeholder: t('.login'), autofocus: true %>
+      <%= f.label :login, t('.login') %><br />
+      <%= f.text_field :login, class: 'form-control', placeholder: 'Login', autofocus: true %>
     </div>
 
     <div class="form-group">
-      <%= f.password_field :password, class: 'form-control', placeholder: t('.password'), autocomplete: 'off' %>
+      <%= f.label :password, t('.password') %><br />
+      <%= f.password_field :password, class: 'form-control', placeholder: 'Password', autocomplete: 'off' %>
     </div>
 
     <div class="checkbox">

--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -2,7 +2,8 @@
   <h3 class="sidebar_title"><%= sidebar.title %></h3>
   <div class="sidebar_body">
     <ul id="archives">
-      <% sidebar.archives.each do |month| %>
+
+      <% sidebar.archives.sort{|a, b| [a[:year], a[:month]] <=> [b[:year], b[:month]]}.reverse.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>
         <li>
           <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]+1) ) %>


### PR DESCRIPTION
_content.html.erb changed:

`<% sidebar.archives.each do |month| %>`

changed to:

`<% sidebar.archives.sort{|a, b| [a[:year], a[:month]] <=> [b[:year], b[:month]]}.reverse.each do |month| %>`
