### PR TITLE
#3 Months sorted incorrectly (Archive Sidebar)

### DIFF
--- a/app/helpers/sidebars/sidebar_helper.rb
+++ b/app/helpers/sidebars/sidebar_helper.rb
@@ -1,0 +1,5 @@
+module Sidebars::SidebarHelper
+  def sort_archives(sidebar)
+    sidebar.archives.sort{|a, b| [a[:year], a[:month]] <=> [b[:year], b[:month]]}.reverse
+  end
+end

--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -2,7 +2,7 @@
   <h3 class="sidebar_title"><%= sidebar.title %></h3>
   <div class="sidebar_body">
     <ul id="archives">
-      <% sidebar.archives.sort{|a, b| [a[:year], a[:month]] <=> [b[:year], b[:month]]}.reverse.each do |month| %>
+      <% sort_archives(sidebar).each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>
         <li>
           <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]+1) ) %>

--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -2,7 +2,7 @@
   <h3 class="sidebar_title"><%= sidebar.title %></h3>
   <div class="sidebar_body">
     <ul id="archives">
-      <% sidebar.archives.each do |month| %>
+      <% sidebar.archives.sort{|a, b| [a[:year], a[:month]] <=> [b[:year], b[:month]]}.reverse.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>
         <li>
           <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]+1) ) %>


### PR DESCRIPTION
_content.html.erb changed:

`<% sidebar.archives.each do |month| %>`

changed to:

`<% sidebar.archives.sort{|a, b| [a[:year], a[:month]] <=> [b[:year], b[:month]]}.reverse.each do |month| %>`
