### PR TITLE
fixed issue #7-Sign-in form displays raw span html in input fields

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,11 +5,11 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <fieldset>
     <div class="form-group">
-      <%= f.text_field :login, class: 'form-control', placeholder: t('.login'), autofocus: true %>
+      <%= f.text_field :login, class: 'form-control', placeholder: 'login', autofocus: true %>
     </div>
 
     <div class="form-group">
-      <%= f.password_field :password, class: 'form-control', placeholder: t('.password'), autocomplete: 'off' %>
+      <%= f.password_field :password, class: 'form-control', placeholder: 'password', autocomplete: 'off' %>
     </div>
 
     <div class="checkbox">


### PR DESCRIPTION
fixed login and password placeholder on:
app/views/devise/sessions/new.html.erb

was:

```
<%= f.text_field :login, class: 'form-control', placeholder: t('.login'), autofocus: true %>    
<%= f.password_field :password, class: 'form-control', placeholder: t('.password'), autocomplete: 'off' %>
```

new:

```
<%= f.text_field :login, class: 'form-control', placeholder: 'login', autofocus: true %>
 <%= f.password_field :password, class: 'form-control', placeholder: 'password', autocomplete: 'off' %>
```
