### PR TITLE
#2 Top Month Always Empty (Archive Sidebar)

### DIFF
--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -5,7 +5,7 @@
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>
         <li>
-          <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]+1) ) %>
+          <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]) ) %>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
Removed +1 from line 8 of lib/archives/app/views/archives_sidebar/_content.html.erb.  Is now:

`<%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]) ) %>
`
