### PR TITLE
Issue #7: Sign-in form displays raw span html in input fields

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,11 +5,11 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <fieldset>
     <div class="form-group">
-      <%= f.text_field :login, class: 'form-control', placeholder: t('.login'), autofocus: true %>
+      <%= f.text_field :login, class: 'form-control', placeholder: 'Login', autofocus: true %>
     </div>
 
     <div class="form-group">
-      <%= f.password_field :password, class: 'form-control', placeholder: t('.password'), autocomplete: 'off' %>
+      <%= f.password_field :password, class: 'form-control', placeholder: 'Password', autocomplete: 'off' %>
     </div>
 
     <div class="checkbox">

--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
Issue #7: Sign-in form displays raw span html in input fields
- changed placeholder in forms from <span class= to 'Login' and 'Password' respectively for each input
- removed debris below input fields
