### PR TITLE
Fixed Issue #8: Post Tags

### DIFF
--- a/app/assets/javascripts/admin_publify.js
+++ b/app/assets/javascripts/admin_publify.js
@@ -41,7 +41,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {


### PR DESCRIPTION
I fixed the save_article_tags function in admin_publify.js 
The function was saving the whole input HTML tag object rather than just it's value. I just popped on a .val() and got the tags to display correctly. 
