### PR TITLE
Fixed issue #8 - Tags displaying as 'object object'

### DIFF
--- a/app/assets/javascripts/admin_publify.js
+++ b/app/assets/javascripts/admin_publify.js
@@ -41,7 +41,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {


### PR DESCRIPTION
Fixed issue #8 
In `app/assets/javascripts/admin_publify.js` changed from:

```
function save_article_tags() {
  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]');
}
```

to:

```
function save_article_tags() {
  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
}
```
