### PR TITLE
fixes #8 (post tags are shown as "object")

### DIFF
--- a/app/assets/javascripts/admin_publify.js
+++ b/app/assets/javascripts/admin_publify.js
@@ -41,7 +41,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {


### PR DESCRIPTION
Added `.val()` to the `save_article_tags` function in admin_publify.js. The jQuery had been capturing the entire tag object from the input; now it's (correctly) grabbing just the value.
