### PR TITLE
Fix Issue #8: Post tags are shown as "object"

### DIFF
--- a/app/assets/javascripts/admin_publify.js
+++ b/app/assets/javascripts/admin_publify.js
@@ -41,7 +41,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {


### PR DESCRIPTION
This fix resolves Issue #8, where new articles, upon being published would not correctly save tags that were created in the popup modal (would later display as "object"). Found that the `save_article_tags` function used a jQuery selector with the intent of capturing the string but instead took the entire object. Applied `.val()` to the selector to correct this.
