### PR TITLE
Fixes Issue #8

### DIFF
--- a/app/assets/javascripts/admin_publify.js
+++ b/app/assets/javascripts/admin_publify.js
@@ -41,7 +41,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {


### PR DESCRIPTION
Fixes Issue #8 by modifying:

> app/javascripts/admin_publify.js

Made the following change to solve issue of Article Tags displaying as 'object'.

Originally:

`function save_article_tags() {
  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
}`

Edited form:

`function save_article_tags() {
  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
}`
