### PR TITLE
Fixes issue #2 and issue #3: Month order and links

### DIFF
--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -5,7 +5,7 @@
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>
         <li>
-          <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]+1) ) %>
+          <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]) ) %>
         </li>
       <% end %>
     </ul>

--- a/lib/archives_sidebar/lib/archives_sidebar.rb
+++ b/lib/archives_sidebar/lib/archives_sidebar.rb
@@ -30,7 +30,7 @@ class ArchivesSidebar < Sidebar
     article_counts = Content.find_by_sql(["select count(*) as count, #{date_func} from contents where type='Article' and published = ? and published_at < ? group by year,month order by year desc,month desc limit ? ", true, Time.now, count.to_i])
 
     @archives = article_counts.map do |entry|
-      month = (entry.month.to_i%12)
+      month = (entry.month.to_i)
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),

--- a/lib/archives_sidebar/lib/archives_sidebar.rb
+++ b/lib/archives_sidebar/lib/archives_sidebar.rb
@@ -30,11 +30,11 @@ class ArchivesSidebar < Sidebar
     article_counts = Content.find_by_sql(["select count(*) as count, #{date_func} from contents where type='Article' and published = ? and published_at < ? group by year,month order by year desc,month desc limit ? ", true, Time.now, count.to_i])
 
     @archives = article_counts.map do |entry|
-      month = (entry.month.to_i%12)+1
+      month = (entry.month.to_i%12)
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),
-        month: month - 1,
+        month: month,
         year: year,
         article_count: entry.count
       }


### PR DESCRIPTION
Fixes the first half of issue #2 
in lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb, changed line 8 from:

```
<%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]+1) ) %>
```

to:

```
<%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]) ) %>
```

Removing the '+1' from this line means that the link will direct to the current month's articles_by_month_path rather than the path for the coming month, which doesn't yet exist and will always be empty. 

Fixes the second half of issue #2 and issue #3  
in lib/archives_sidebar/lib/archives_sidebar.rb changed line 33 from:

```
month = (entry.month.to_i%12)+1
```

to:

```
month = (entry.month.to_i)
```

and line 37 from:

```
month: month - 1,
```

to:

```
month: month,
```

The changes to line 33 sets the archive month to the entry's actual month instead of the remainder of the month + 1 divided by 12. The change to line 37 prevents further changes to the archive's month, which is set in line 33 and shouldn't be incremented. 

*\* The bugfix for #3 was difficult to test since we're only able to create posts for May, but I think that this should do the trick. 
