### PR TITLE
Issue #2: Fixes the top month and mismatched month issue

### DIFF
--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -5,7 +5,7 @@
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>
         <li>
-          <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]+1) ) %>
+          <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month])) %>
         </li>
       <% end %>
     </ul>

--- a/lib/archives_sidebar/lib/archives_sidebar.rb
+++ b/lib/archives_sidebar/lib/archives_sidebar.rb
@@ -30,11 +30,11 @@ class ArchivesSidebar < Sidebar
     article_counts = Content.find_by_sql(["select count(*) as count, #{date_func} from contents where type='Article' and published = ? and published_at < ? group by year,month order by year desc,month desc limit ? ", true, Time.now, count.to_i])
 
     @archives = article_counts.map do |entry|
-      month = (entry.month.to_i%12)+1
+      month = entry.month.to_i
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),
-        month: month - 1,
+        month: month,
         year: year,
         article_count: entry.count
       }


### PR DESCRIPTION
Fixes #2
=>File : lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb

Taking away +1 on line 8 , redirects the user to the articles_month_path that has exact month and not the month ahead (e.g. if user clicks on March, user is brought to March page and not April).

This fix will also pave the way to address the mismatched month issue in,

=> File : lib/archives_sidebar/lib/archives_sidebar.rb

Removing the divisor 12 and +1 on line 33, makes sure that the entry count is exact, avoiding ghost counts and an empty archive month.

Removing the -1 from line 33, that the exact month is generated and not a month behind.
