### PR TITLE
Fixes Issue#7: Sign-in form displays raw html

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,11 +5,11 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <fieldset>
     <div class="form-group">
-      <%= f.text_field :login, class: 'form-control', placeholder: t('.login'), autofocus: true %>
+      <%= f.text_field :login, class: 'form-control', placeholder: 'login' , autofocus: true %>
     </div>
 
     <div class="form-group">
-      <%= f.password_field :password, class: 'form-control', placeholder: t('.password'), autocomplete: 'off' %>
+      <%= f.password_field :password, class: 'form-control', placeholder: 'password' , autocomplete: 'off' %>
     </div>
 
     <div class="checkbox">


### PR DESCRIPTION
Fixes Issue #7
Puts in the correct placeholder for login and password field to get rid of HTML span tag and other text.
